### PR TITLE
update express to latest 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "istanbul": "0",
     "jshint": "2",
     "jshint-full-path": "0",
-    "supertest": "~0.8.1"
+    "supertest": "balaclark/supertest"
   }
 }


### PR DESCRIPTION
Express 3.4.4 depends on an outdated version of qs that contains a vulnerability
and is causing tests to fail in other projects (RIBAJ).

Same goes for supertest 0.8.1.

https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
