### PR TITLE
Feature - Cors - Optional Options for Optional Header Options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var api = createApi(options)
 server.get('/', homepage)
 server.post('/form', submit)
 
-// This tells the api that you've finised adding your routes
+// This tells the api that you've finished adding your routes
 // and you now want it to add the error handling middleware
 server.emit('preBoot')
 
@@ -31,11 +31,14 @@ server.listen(port)
 
 ### var api = createApi(Object: options)
 
-Create an API instance. There are two options available:
+Create an API instance. There are options available:
 
 - `checkOrigin` - a function with the signature `function (url, cb) {}` to check `req.headers.origin`. `cb(null, true)` to allow and `origin`, `cb(null, false)` to deny an origin. Defaults to `cb(null, true)` for all requests, meaning all cross-domain requests are allowed. It is up to the user to implement their whitelist/blacklist.
 - `logger` - a logger object with methods `debug()`, `info()`, `warn()` and `error()` (default: `console`).
 - `maxBodySize` - an option to be passed along to the [body-parser json middleware](https://github.com/expressjs/body-parser#limit) function. If this is a number it will be the number of bytes, otherwise it will be parsed by the [bytes module](https://github.com/visionmedia/bytes.js) (default: `undefined` which falls back to the body parser default of `'100kB'`).
+- `initialMiddleware` - an Express middleware function that will be used before all other middleware. Useful for Sentry error handlers.
+- `corsOptions` - an object with the following keys:
+  - `exposeHeaders` - sets `Access-Control-Expose-Headers`
 
 *For backwards compatibility, the `allowedDomains` option still works and generates a `checkOrigin` function for you.*
 

--- a/api.js
+++ b/api.js
@@ -10,6 +10,9 @@ var createServer = require('./server')
     , logger: console
     , maxBodySize: '100kb'
     , initialMiddleware: null
+    , corsOptions:
+      { exposeHeaders: ''
+      }
     }
 
 /*

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -4,25 +4,31 @@ module.exports = createCorsMiddleware
  * Set cross-domain oriented headers, and check incoming
  * requests to ensure they come from allowed domains.
  */
-function createCorsMiddleware(checkDomain) {
+function createCorsMiddleware(checkOrigin, options) {
+  options = options || {}
 
   return function (req, res, next) {
 
     if (req.headers.origin) {
 
       // Check if this client should be served
-      checkDomain(req.headers.origin, function (err, allowed) {
+      checkOrigin(req.headers.origin, function (err, allowed) {
         if (err) return next(err)
 
         if (!allowed) return res.sendStatus(403)
 
-        // Request came from allowed domain so set acces control headers
-        res.set(
+        // Request came from allowed domain so set access control headers
+        var headers =
           { 'Access-Control-Allow-Origin': req.headers.origin
           , 'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-cf-date, x-cf-ttl, *'
           , 'Access-Control-Request-Headers': '*'
           , 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE, PATCH'
-          })
+          }
+          if (options.exposeHeaders) {
+            headers['Access-Control-Expose-Headers'] = options.exposeHeaders
+          }
+
+        res.set(headers)
 
         // Don't call next() if this is a preflight CORS check
         if (req.method === 'OPTIONS') {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "jshint . --reporter=./node_modules/jshint-full-path/index.js",
     "pretest": "npm run-script lint",
     "test": "NODE_ENV=test istanbul cover ./node_modules/.bin/_mocha -- -R spec --recursive",
+    "run-test": "./node_modules/.bin/_mocha $@",
     "posttest": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100 && rm -rf coverage",
     "prepublish": "npm test && npm prune"
   },

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ module.exports = createServer
 var express = require('express')
   , logger = require('./middleware/logger')
   , tag = require('./middleware/tag')
-  , cors = require('./middleware/cors')
   , accepts = require('./middleware/accepts')
   , contentType = require('./middleware/content-type')
   , cors = require('./middleware/cors')
@@ -40,7 +39,7 @@ function createServer(options) {
     .use(responseTime())
 
     // Whitelist cross domain requests
-    .use(cors(options.checkOrigin))
+    .use(cors(options.checkOrigin, options.corsOptions))
 
     // Body parse API for JSON content type
     .use(bodyParser.json({ limit: options.maxBodySize }))

--- a/test/middleware/cors/integration.test.js
+++ b/test/middleware/cors/integration.test.js
@@ -1,4 +1,5 @@
 var request = require('supertest')
+  , assert = require('assert')
   , express = require('express')
   , createMiddleware = require('../../../middleware/cors')
 
@@ -48,4 +49,34 @@ describe('middleware/cors integration tests', function () {
       .end(done)
   })
 
+  it('should not add expose header if options are not set', function (done) {
+    request(app)
+      .options('/')
+      .set('Origin', 'http://127.0.0.1/')
+      .expect(200)
+      .end(function (error, req) {
+        if (error) return done(error)
+        assert.strictEqual(req.headers['Access-Control-Expose-Headers'], undefined)
+        done()
+      })
+  })
+
+  it('should add expose header if options set', function (done) {
+    var appWithOptions = express()
+    appWithOptions.use(createMiddleware(
+      checkOrigin,
+      {
+        exposeHeaders: 'Filename'
+      }
+    ))
+    appWithOptions.all('/', function (req, res) {
+      res.sendStatus(200)
+    })
+    request(appWithOptions)
+      .options('/')
+      .set('Origin', 'http://127.0.0.1/')
+      .expect('Access-Control-Expose-Headers', 'Filename')
+      .expect(200)
+      .end(done)
+  })
 })

--- a/test/middleware/cors/unit.test.js
+++ b/test/middleware/cors/unit.test.js
@@ -65,6 +65,34 @@ describe('middleware/cors unit tests', function () {
 
   })
 
+  it(
+    'should set the correct response headers for a request with an origin in the allow list with additional options'
+  , function (done) {
+
+    var allowed = [ 'http://127.0.0.1/' ]
+
+    function checkOrigin(url, cb) {
+      cb(null, allowed.indexOf(url) !== -1)
+    }
+
+    function mockSet(headers) {
+      assert.deepEqual(
+        { 'Access-Control-Allow-Origin': 'http://127.0.0.1/'
+        , 'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-cf-date, x-cf-ttl, *'
+        , 'Access-Control-Request-Headers': '*'
+        , 'Access-Control-Expose-Headers': 'Filename'
+        , 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE, PATCH'
+        }, headers)
+    }
+
+  createMiddleware(
+    checkOrigin
+  , { exposeHeaders: 'Filename'})({ headers: { origin: allowed[0] } }, { set: mockSet }, function () {
+      done()
+    })
+
+  })
+
   it('should not call next() if req.method is OPTIONS', function (done) {
 
     var allowed = [ 'http://127.0.0.1/' ]


### PR DESCRIPTION
Allows setting `Access-Control-Expose-Headers`, which when performing cross origin requests from the CMS, lets JS access non-standard headers.

In my case, I am responding with a binary file, with the filename included in a custom `Filename` header.

Also took the opportunity to add some QOL things, .editorconfig and `run-test` command.

I'll migrate this to `@clocklimited/cf-api` afterwards.