### PR TITLE
fix(cors): add Access-Control-Allow-Credentials

### DIFF
--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -21,6 +21,7 @@ function createCorsMiddleware(checkOrigin, options) {
         var headers =
           { 'Access-Control-Allow-Origin': req.headers.origin
           , 'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-cf-date, x-cf-ttl, *'
+          , 'Access-Control-Allow-Credentials': true
           , 'Access-Control-Request-Headers': '*'
           , 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE, PATCH'
           }

--- a/test/middleware/cors/unit.test.js
+++ b/test/middleware/cors/unit.test.js
@@ -54,6 +54,7 @@ describe('middleware/cors unit tests', function () {
       assert.deepEqual(
         { 'Access-Control-Allow-Origin': 'http://127.0.0.1/'
         , 'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-cf-date, x-cf-ttl, *'
+        , 'Access-Control-Allow-Credentials': true
         , 'Access-Control-Request-Headers': '*'
         , 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE, PATCH'
         }, headers)
@@ -79,6 +80,7 @@ describe('middleware/cors unit tests', function () {
       assert.deepEqual(
         { 'Access-Control-Allow-Origin': 'http://127.0.0.1/'
         , 'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-cf-date, x-cf-ttl, *'
+        , 'Access-Control-Allow-Credentials': true
         , 'Access-Control-Request-Headers': '*'
         , 'Access-Control-Expose-Headers': 'Filename'
         , 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE, PATCH'


### PR DESCRIPTION
This is required so requests with credentials can correctly query the API process.

For example, this is required when using Apollo client and hitting a graphql service attached to a cf-api instance.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials